### PR TITLE
Refactor PokemonService to fetch and map Pokemon details

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "prettier.printWidth": 500
+}

--- a/PokePediax/src/app/Interfaces/pokeApi.ts
+++ b/PokePediax/src/app/Interfaces/pokeApi.ts
@@ -1,11 +1,5 @@
-export interface Data {
-  count: number;
-  next: string;
-  previous?: any;
-  results: Resultado[];
-}
-
 export interface Resultado {
   name: string;
   url: string;
+  types: string[]; // Nuevo campo para almacenar los tipos del Pokémon
 }

--- a/PokePediax/src/app/Services/pokemon.service.ts
+++ b/PokePediax/src/app/Services/pokemon.service.ts
@@ -32,9 +32,25 @@ export class PokemonService {
         `https://pokeapi.co/api/v2/pokemon?limit=${limit}`
       );
       const data = await response.json();
-      return data.results;
+
+      // Mapear la respuesta para obtener los detalles de cada Pokémon
+      const pokemonList: Resultado[] = await Promise.all(
+        data.results.map(async (pokemon: Resultado) => {
+          const pokemonDataResponse = await fetch(pokemon.url);
+          const pokemonData = await pokemonDataResponse.json();
+          const types = pokemonData.types.map((type: any) => type.type.name);
+          return {
+            name: pokemon.name,
+            url: pokemon.url,
+            types: types,
+          };
+        })
+      );
+
+      return pokemonList;
     } catch (error) {
       console.error(error);
+      throw error; // Agregar este retorno para manejar errores correctamente
     }
   }
 


### PR DESCRIPTION
Refactor the `PokemonService` to fetch and map the details of each Pokemon. This includes making a request to the Pokemon API for each Pokemon in the list, retrieving their types, and returning an array of Pokemon objects with their name, URL, and types. Additionally, handle errors by throwing an error to be handled correctly.